### PR TITLE
fix: restrict edit and delete access

### DIFF
--- a/app/(root)/products/ProductClient.tsx
+++ b/app/(root)/products/ProductClient.tsx
@@ -73,7 +73,6 @@ const ProductClient = ({
   categories,
   types,
 }: Props) => {
-  console.log(allocationProducts);
   const [open, setOpen] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
   const [openFilterDialog, setOpenFilterDialog] = useState(false);

--- a/components/shared/table/columns/ClassificationColumns.tsx
+++ b/components/shared/table/columns/ClassificationColumns.tsx
@@ -15,24 +15,19 @@ import { deleteClassification } from "@/lib/actions/classification.actions";
 import { UserRoleEnum } from "@/enums";
 import { hasPermission } from "@/lib/auth";
 import DialogFormButton from "../../buttons/DialogFormButton";
+import { toast } from "sonner";
 
 export const visibleClassificationColumns = (userRole: UserRoleEnum) => {
   return createColumnConfig({
     desktop: {
       name: true,
       description: true,
-      actions: hasPermission(userRole, [
-        UserRoleEnum.ADMIN,
-        UserRoleEnum.LOGISTICS_SPECIALIST,
-      ]),
+      actions: hasPermission(userRole, [UserRoleEnum.ADMIN]),
     },
     mobile: {
       name: true,
       description: true,
-      actions: hasPermission(userRole, [
-        UserRoleEnum.ADMIN,
-        UserRoleEnum.LOGISTICS_SPECIALIST,
-      ]),
+      actions: hasPermission(userRole, [UserRoleEnum.ADMIN]),
     },
   });
 };
@@ -88,9 +83,25 @@ const ClassificationActionsCell = React.memo(
         </EditDialog>
         <DeleteDialog
           title="Delete Classification"
-          deleteAction={async () =>
-            await deleteClassification(classification.id, classificationType)
-          }
+          deleteAction={async () => {
+            try {
+              const response = await deleteClassification(
+                classification.id,
+                classificationType,
+              );
+              return response;
+            } catch (error: any) {
+              toast.error(error.message, {
+                position: "top-center",
+                duration: 1500,
+              });
+              return {
+                status: 500,
+                data: null,
+                errors: { general: [error.message] },
+              };
+            }
+          }}
           placeholder="Are you sure you want to delete the classification?"
         />
       </div>

--- a/components/shared/table/columns/ProductColumns.tsx
+++ b/components/shared/table/columns/ProductColumns.tsx
@@ -35,6 +35,10 @@ import {
 import { createColumnConfig } from "../column.config";
 import { DataTableColumnHeader } from "../data-table-column-header";
 import DialogFormButton from "../../buttons/DialogFormButton";
+import { toast } from "sonner";
+import { ApiResponse } from "@/types/api";
+import { formatErrorResponse } from "@/lib/formatters";
+import { showSuccessMessage } from "@/lib/utils";
 
 export const visibleProductColumns = (userRole: UserRoleEnum) => {
   return createColumnConfig({
@@ -132,9 +136,31 @@ const ProductActionsCell = React.memo(({ product }: { product: Product }) => {
         </ResponsiveDialogFooter>
       </EditDialog>
       <DeleteDialog
-        title={"Delete Product"}
-        deleteAction={async () => await deleteProduct(product.id)}
-        placeholder={"Are you sure you want to delete the product?"}
+        title="Delete Product"
+        deleteAction={async () => {
+          const result: ApiResponse<string> = await deleteProduct(product.id);
+          console.log(result);
+
+          if (
+            result.data &&
+            typeof result.data === "object" &&
+            "message" in result.data
+          ) {
+            toast.success((result.data as { message: string }).message, {
+              position: "top-center",
+              duration: 1500,
+            });
+          }
+
+          if (result.errors) {
+            toast.error(formatErrorResponse(result.errors), {
+              position: "top-center",
+              duration: 2000,
+            });
+          }
+          return result;
+        }}
+        placeholder="Are you sure you want to delete the product?"
       />
     </div>
   );

--- a/lib/actions/classification.actions.ts
+++ b/lib/actions/classification.actions.ts
@@ -68,11 +68,19 @@ async function deleteClassification(
   id: string,
   classificationType: ClassificationType,
 ): Promise<ApiResponse<string>> {
-  return fetchAndHandleResponse({
+  const response = await fetchAndHandleResponse<string>({
     jwt: (await getSession())?.access,
     url: `${getClassificationUrl(classificationType)}${id}/`,
     method: "DELETE",
   });
+
+  if (response.status === 500) {
+    throw new Error(
+      "Failed to delete classification due to existing connections to a product or asset.",
+    );
+  }
+
+  return response;
 }
 
 export {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -68,7 +68,6 @@ export async function fetchAndHandleResponse<T>({
     if (jwt) {
       headers["Authorization"] = `Bearer ${jwt}`;
     }
-
     if (contentType) {
       headers["Content-Type"] = contentType;
     }
@@ -80,16 +79,20 @@ export async function fetchAndHandleResponse<T>({
     };
 
     const response = await fetch(url, requestOptions);
+    const status = response.status;
 
     if (!response.ok) {
-      const errorData: ErrorResponse = await response.json();
-      return { data: null, errors: errorData };
+      let errorData: ErrorResponse = { general: [`HTTP Error ${status}`] };
+      try {
+        errorData = await response.json();
+      } catch (e) {}
+      return { status, data: null, errors: errorData };
     }
-    const data: T = await response.json();
 
-    return { data, errors: null };
+    const data: T = await response.json();
+    return { status, data, errors: null };
   } catch (error: any) {
-    return { data: null, errors: { general: [error.message] } };
+    return { status: 0, data: null, errors: { general: [error.message] } };
   }
 }
 

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -4,6 +4,7 @@ export type ErrorResponse = {
 };
 
 export type ApiResponse<T> = {
+  status: number;
   data: T | null;
   errors: ErrorResponse | null;
 };


### PR DESCRIPTION
closes issue #40 

Original issue: Access to modify classification, assets, and products when it is in an allocation #40
Backend pr: https://github.com/Charming-Software-Solutions/adtalk-dms-backend/pull/25

## Changes made:

- When a classification is connected/referenced to an existing product or asset, it can no longer be delete and will show an appropriate message.
- Products/assets that are referenced in an allocation can no longer be deleted wherein the allocation should be deleted first.
- Only admins can edit or delete classifacations

## Where to test
**site:** https://dms-qa.adtalk.org/
## **Credentials ay nasa gc, pa check na langs, thanks**

## Additional Notes:
- if may tanong kayo or like insights, comment niyo na lang dito sa pull request
- pag okay na yung mga changes, click niyo lang yung approve button